### PR TITLE
Update ctap-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "ctap-types"
 version = "0.1.2"
-source = "git+https://github.com/nitrokey/ctap-types.git?rev=de8aa1f3dc4f773160f427680e854759bed869d7#de8aa1f3dc4f773160f427680e854759bed869d7"
+source = "git+https://github.com/nitrokey/ctap-types.git?tag=v0.1.2-nitrokey.4#702b5b5248f88091b22c46c936cb0f99425c0a61"
 dependencies = [
  "bitflags",
  "cbor-smol",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?rev=82a85dc5fd88d32259b9e3f4f5542bc28b8c4f55#82a85dc5fd88d32259b9e3f4f5542bc28b8c4f55"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.7#2f49017eec5a87bd2570593571b87a15a9890ed0"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag =
 
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.3" }
-ctap-types = { git = "https://github.com/nitrokey/ctap-types.git", rev = "de8aa1f3dc4f773160f427680e854759bed869d7" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", rev = "82a85dc5fd88d32259b9e3f4f5542bc28b8c4f55" }
+ctap-types = { git = "https://github.com/nitrokey/ctap-types.git", tag = "v0.1.2-nitrokey.4" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.7" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }
 serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }
 

--- a/src/lib/ctap_app.rs
+++ b/src/lib/ctap_app.rs
@@ -132,13 +132,18 @@ where
             let data = &data[0].id;
             let rpid_hash = hash(&mut w.wc.trussed, request.rp_id.as_bytes())
                 .map_err(|_| ctap2::Error::InvalidParameter as u8)?;
+            let pin_auth = request
+                .pin_auth
+                .map(|s| Bytes::from_slice(s))
+                .transpose()
+                .map_err(|_| ctap2::Error::InvalidParameter as u8)?;
             let maybe_output = w.bridge_u2f_to_webcrypt_raw(
                 output,
                 data,
                 RequestDetails {
                     rpid: rpid_hash.clone(),
                     source: RS_FIDO2,
-                    pin_auth: request.pin_auth.copied(),
+                    pin_auth,
                 },
             );
 

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -4,7 +4,6 @@ use crate::commands_types::WebcryptMessage;
 use crate::types::Error::BadFormat;
 use crate::types::TRANSPORT_CMD_ID::COMM_CMD_WRITE;
 use crate::{Bytes, Message};
-use ctap_types::ctap2::PinAuth;
 use delog::log;
 use heapless_bytes::Bytes32;
 
@@ -206,7 +205,7 @@ pub enum RequestSource {
 pub struct RequestDetails {
     pub source: RequestSource,
     pub rpid: Bytes32,
-    pub pin_auth: Option<PinAuth>,
+    pub pin_auth: Option<Bytes<16>>,
 }
 
 impl From<Message> for WebcryptRequest {


### PR DESCRIPTION
This patch updates the ctap-types dependency.  PinAuth (a type alias for Bytes<16>) is now replaced by a reference to a byte slice.